### PR TITLE
Fixing Client Certificate Based Authentication for Certificates without OCSP OID id-ad-ocsp

### DIFF
--- a/native/src/sslutils.c
+++ b/native/src/sslutils.c
@@ -736,7 +736,8 @@ static char **decode_OCSP_url(ASN1_OCTET_STRING *os, apr_pool_t *p)
 
     if ((response = apr_pcalloc(p, sizeof(char *))) == NULL)
         return NULL;
-    if (parse_ASN1_Sequence(ocsp_urls, &response, &numofresponses, p))
+    if (parse_ASN1_Sequence(ocsp_urls, &response, &numofresponses, p) ||
+		    numofresponses == 0)
         response = NULL;
     return response;
 }


### PR DESCRIPTION
###### Issue:

Certificate base authentication was failing on Tomcat 9. The connection used to get reset(RST) without any prior or post warnings. After some initial debugging using Wireshark, I came to know that the initial handshake was successful, yet the connection was ended abruptly by the tomcat server. So I had to look into the Tomcat native wrapper(1.2.19)(http://tomcat.apache.org/native-doc/) over OpenSSL to debug the issue further.

###### RCA:
1. After a lot of debugging I came to know that the origin of the failure was not the Client Certificate Authentication part. Though client authentication was successful every time, some other module was changing the error code from 0 to 50(source: `tomcat-native-1.2.19-src/native/src/sslutils.c`, functions: `handshake` and `SSL_callback_SSL_verify`)
2. On referring the error code from [here](https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h), I came to know OCSP verification part was causing the application failure(Error code `X509_V_ERR_APPLICATION_VERIFICATION`). OCSP reference: https://en.wikipedia.org/wiki/Online_Certificate_Status_Protocol
3. On debugging further, I found that client certificate was missing the OCSP URI info from one of the extensions(Authority Information Access OR NID_info_access). Refer following URL for more info on extensions(https://www.openssl.org/docs/man1.1.0/crypto/X509_get_ext_d2i.html)
4. From these RFCs(https://tools.ietf.org/html/rfc5280 and https://tools.ietf.org/html/rfc2560) I confirmed that the OCSP URI Info(OID id-ad-ocsp) may or may not be included in the certificate by the issuer.
5. This causes the OCSP verification to fail, causing the connection reset(source: `tomcat-native-1.2.19-src/native/src/sslutils.c`, function: ssl_ocsp_request). I could confirm from the code that OCSP verification was done, even though ocsp_urls were empty(a null check was present)
6. On searching for the source online, I found the code annotations for [sslutils.c](https://github.com/apache/tomcat-native/blame/3cd7fdceee92c53ca726ffee33b49bf2c77acaba/native/src/sslutils.c#L1096)
7. With help of that I could locate the exact [changeset](https://github.com/apache/tomcat-native/commit/23c205ceb277f73fd95d093adbc2c4890c574c1b?diff=split) which caused the trouble.
8. On inspecting the Tomcat Native code further(source: `tomcat-native-1.2.19-src/native/src/sslutils.c`, functions: ssl_ocsp_request, decode_OCSP_url and parse_ASN1_Sequence) I was able to pin point the root cause.
9. The decode_OCSP_url function returns a null value if parse_ASN1_Sequence returns a non-zero value(failure case). But even when OCSP oid is missing from the certificate extension, parse_ASN1_Sequence returns a zero(success case), making decode_OCSP_url to return a non null value, which in turn makes ssl_ocsp_request validate an empty OCSP URL.

###### Fix:
In the Tomcat Native code(source: tomcat-native-1.2.19-src/native/src/sslutils.c, functions: ssl_ocsp_request, decode_OCSP_url and parse_ASN1_Sequence), parse_ASN1_Sequence also modifies the number of OCSP URLs found. We can add additional check in decode_OCSP_url that if numofresponses ==0, then also return NULL. This will make ssl_ocsp_request skip the unnecessary OCSP verification, when OSCP URL info is missing from the client certificate.

###### Testing:
1. Apply the fix, recompile the tc native source using `make` and `make install` 
2. Replace the recompiled libs (OpenSSL and APR) 
3. Restart Tomcat, make sure startup is without any warnings and errors
4. Make sure connection over the connector configured for Client Certificate Authentication is not resetting anymore
