### PR TITLE
Install libtcnative** files in $prefix/bin folder

### DIFF
--- a/native/Makefile.in
+++ b/native/Makefile.in
@@ -84,7 +84,7 @@ install: $(TARGET_LIB)
 	list='$(INSTALL_SUBDIRS)'; for i in $$list; do \
 		( cd $$i ; $(MAKE) DESTDIR=$(DESTDIR) install ); \
 	done
-	$(LIBTOOL) --mode=install $(INSTALL) -m 755 $(TARGET_LIB) $(DESTDIR)$(libdir)
+	$(LIBTOOL) --mode=install $(INSTALL) -m 755 $(TARGET_LIB) $(DESTDIR)$(bindir)
 
 $(TARGET_LIB): $(OBJECTS)
 	$(LINK) @lib_target@ $(TCNATIVE_LDFLAGS) $(TCNATIVE_LIBS)


### PR DESCRIPTION
$prefix == $CATALINA_HOME

As explained by Remy Maucherat at https://markmail.org/message/3fb7o7xljawktilr the native libraries should be installed at $CATALINA_HOME/bin instead of $CATALINA_HOME/lib folder.