### PR TITLE
Expose support for Unix Domain Sockets in APR v1.6 and up.

### DIFF
--- a/java/org/apache/tomcat/jni/Address.java
+++ b/java/org/apache/tomcat/jni/Address.java
@@ -41,7 +41,7 @@ public class Address {
     /**
      * Create apr_sockaddr_t from hostname, address family, and port.
      * @param hostname The hostname or numeric address string to resolve/parse, the
-     *                 path of the unix domain socket, or NULL to build an address
+     *                 path of the Unix Domain Socket, or NULL to build an address
      *                 that corresponds to 0.0.0.0 or ::
      * @param family The address family to use, or APR_UNSPEC if the system should
      *               decide.

--- a/java/org/apache/tomcat/jni/Address.java
+++ b/java/org/apache/tomcat/jni/Address.java
@@ -40,8 +40,9 @@ public class Address {
 
     /**
      * Create apr_sockaddr_t from hostname, address family, and port.
-     * @param hostname The hostname or numeric address string to resolve/parse, or
-     *               NULL to build an address that corresponds to 0.0.0.0 or ::
+     * @param hostname The hostname or numeric address string to resolve/parse, the
+     *                 path of the unix domain socket, or NULL to build an address
+     *                 that corresponds to 0.0.0.0 or ::
      * @param family The address family to use, or APR_UNSPEC if the system should
      *               decide.
      * @param port The port number.

--- a/java/org/apache/tomcat/jni/Library.java
+++ b/java/org/apache/tomcat/jni/Library.java
@@ -177,6 +177,9 @@ public final class Library {
     /* Is the O_NONBLOCK flag inherited from listening sockets?
      */
     public static boolean APR_O_NONBLOCK_INHERITED  = false;
+    /* Support for Unix Domain Sockets.
+     */
+    public static boolean APR_HAVE_UNIX           = false;
 
 
     public static int APR_SIZEOF_VOIDP;
@@ -244,6 +247,7 @@ public final class Library {
             APR_CHARSET_EBCDIC      = has(18);
             APR_TCP_NODELAY_INHERITED = has(19);
             APR_O_NONBLOCK_INHERITED  = has(20);
+            APR_HAVE_UNIX             = has(22);
             if (APR_MAJOR_VERSION < 1) {
                 throw new UnsatisfiedLinkError("Unsupported APR Version (" +
                                                aprVersionString() + ")");

--- a/java/org/apache/tomcat/jni/Library.java
+++ b/java/org/apache/tomcat/jni/Library.java
@@ -177,6 +177,9 @@ public final class Library {
     /* Is the O_NONBLOCK flag inherited from listening sockets?
      */
     public static boolean APR_O_NONBLOCK_INHERITED  = false;
+    /* Poll operations are interruptable by apr_pollset_wakeup().
+     */
+    public static boolean APR_POLLSET_WAKEABLE      = false;
     /* Support for Unix Domain Sockets.
      */
     public static boolean APR_HAVE_UNIX           = false;
@@ -247,7 +250,8 @@ public final class Library {
             APR_CHARSET_EBCDIC      = has(18);
             APR_TCP_NODELAY_INHERITED = has(19);
             APR_O_NONBLOCK_INHERITED  = has(20);
-            APR_HAVE_UNIX             = has(21);
+            APR_POLLSET_WAKEABLE      = has(21);
+            APR_HAVE_UNIX             = has(22);
             if (APR_MAJOR_VERSION < 1) {
                 throw new UnsatisfiedLinkError("Unsupported APR Version (" +
                                                aprVersionString() + ")");

--- a/java/org/apache/tomcat/jni/Library.java
+++ b/java/org/apache/tomcat/jni/Library.java
@@ -247,7 +247,7 @@ public final class Library {
             APR_CHARSET_EBCDIC      = has(18);
             APR_TCP_NODELAY_INHERITED = has(19);
             APR_O_NONBLOCK_INHERITED  = has(20);
-            APR_HAVE_UNIX             = has(22);
+            APR_HAVE_UNIX             = has(21);
             if (APR_MAJOR_VERSION < 1) {
                 throw new UnsatisfiedLinkError("Unsupported APR Version (" +
                                                aprVersionString() + ")");

--- a/java/org/apache/tomcat/jni/Socket.java
+++ b/java/org/apache/tomcat/jni/Socket.java
@@ -79,6 +79,7 @@ public class Socket {
     public static final int APR_UNSPEC = 0;
     public static final int APR_INET   = 1;
     public static final int APR_INET6  = 2;
+    public static final int APR_UNIX   = 3;
 
     public static final int APR_PROTO_TCP  =   6; /** TCP  */
     public static final int APR_PROTO_UDP  =  17; /** UDP  */

--- a/native/include/tcn.h
+++ b/native/include/tcn.h
@@ -281,11 +281,20 @@ typedef struct {
 #define APR_INET6 APR_INET
 #endif
 
+#ifdef APR_UNIX
+#define GET_S_FAMILY(T, F)           \
+    if (F == 0) T = APR_UNSPEC;      \
+    else if (F == 1) T = APR_INET;   \
+    else if (F == 2) T = APR_INET6;  \
+    else if (F == 3) T = APR_UNIX;   \
+    else T = F
+#else
 #define GET_S_FAMILY(T, F)           \
     if (F == 0) T = APR_UNSPEC;      \
     else if (F == 1) T = APR_INET;   \
     else if (F == 2) T = APR_INET6;  \
     else T = F
+#endif
 
 #define GET_S_TYPE(T, F)             \
     if (F == 0) T = SOCK_STREAM;     \

--- a/native/src/info.c
+++ b/native/src/info.c
@@ -198,6 +198,9 @@ static void fill_ainfo(JNIEnv *e, jobject obj, apr_sockaddr_t *info)
     if (info->family == APR_UNSPEC) f = 0;
     else if (info->family == APR_INET) f = 1;
     else if (info->family == APR_INET6) f = 2;
+#ifdef APR_UNIX
+    else if (info->family == APR_UNIX) f = 3;
+#endif
     else f = info->family;
 
     SET_AINFO_J(pool, P2J(info->pool));

--- a/native/src/jnilib.c
+++ b/native/src/jnilib.c
@@ -431,6 +431,11 @@ TCN_IMPLEMENT_CALL(jboolean, Library, has)(TCN_STDARGS, jint what)
             rv = JNI_TRUE;
 #endif
         break;
+        case 22:
+#ifdef APR_UNIX
+            rv = JNI_TRUE;
+#endif
+        break;
     }
     return rv;
 }

--- a/native/src/network.c
+++ b/native/src/network.c
@@ -19,6 +19,7 @@
 #ifdef TCN_DO_STATISTICS
 
 #include "apr_atomic.h"
+#include "apr_file_io.h"
 
 static volatile apr_uint32_t sp_created  = 0;
 static volatile apr_uint32_t sp_closed   = 0;
@@ -79,6 +80,15 @@ static apr_status_t sp_socket_cleanup(void *data)
         (*s->net->cleanup)(s->opaque);
     if (s->sock) {
         apr_socket_t *as = s->sock;
+        apr_sockaddr_t *sa = NULL;
+        apr_socket_addr_get(&sa, APR_LOCAL, as);
+        if (sa && sa->family == APR_UNIX) {
+            char *sock;
+            apr_getnameinfo(&sock, sa, 0);
+            if (sock) {
+                apr_file_remove(sock, s->pool);
+            }
+        }
         s->sock = NULL;
         apr_socket_close(as);
     }

--- a/native/src/network.c
+++ b/native/src/network.c
@@ -80,6 +80,7 @@ static apr_status_t sp_socket_cleanup(void *data)
         (*s->net->cleanup)(s->opaque);
     if (s->sock) {
         apr_socket_t *as = s->sock;
+#ifdef APR_UNIX
         apr_sockaddr_t *sa = NULL;
         apr_socket_addr_get(&sa, APR_LOCAL, as);
         if (sa && sa->family == APR_UNIX) {
@@ -89,6 +90,7 @@ static apr_status_t sp_socket_cleanup(void *data)
                 apr_file_remove(sock, s->pool);
             }
         }
+#endif
         s->sock = NULL;
         apr_socket_close(as);
     }

--- a/xdocs/index.xml
+++ b/xdocs/index.xml
@@ -52,6 +52,7 @@
     <li>Non-blocking I/O for Keep-Alive requests (between requests)</li>
     <li>Uses OpenSSL for TLS/SSL capabilities (if supported by linked APR library)</li>
     <li>FIPS 140-2 support for TLS/SSL (if supported by linked OpenSSL library)</li>
+    <li>Support for IPv4, IPv6 and Unix Domain Sockets</li>
   </ul>
 
 </section>
@@ -174,6 +175,14 @@ list of changes.
     <p>
       Please see the Apache Tomcat documentation for configuration specifics.
     </p>
+
+    <p>
+      When using unix domain sockets a cleanup is registered to delete the
+      socket on destruction of the socket, or shutdown of the application.
+      Should the application terminate abnormally, the socket deletion will
+      need to be handled by the caller or by the administrator.
+    </p>
+
   </subsection>
 
 <subsection name="UNIX">

--- a/xdocs/index.xml
+++ b/xdocs/index.xml
@@ -187,11 +187,11 @@ export LD_LIBRARY_PATH</source>
    Start tomcat and check for the messages like this ones:
   </p>
    <source wrapped="true"
->Feb 8, 2015 12:27:41 PM org.apache.catalina.core.AprLifecycleListener init
+>Nov 29, 2020 12:27:41 PM org.apache.catalina.core.AprLifecycleListener init
 INFO: Loaded APR based Apache Tomcat Native library 1.x.y.
-Feb 8, 2015 12:27:41 PM org.apache.catalina.core.AprLifecycleListener init
-INFO: APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true].
-Feb 8, 2015 12:27:41 PM org.apache.coyote.http11.Http11AprProtocol init
+Nov 29, 2020 12:27:41 PM org.apache.catalina.core.AprLifecycleListener init
+INFO: APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true], uds [true].
+Nov 29, 2020 12:27:41 PM org.apache.coyote.http11.Http11AprProtocol init
 INFO: Initializing Coyote HTTP/1.1 on http-8080</source>
 
   <p>
@@ -214,11 +214,11 @@ INFO: Initializing Coyote HTTP/1.1 on http-8080</source>
     Start tomcat and check for the messages like this ones:
   </p>
   <source wrapped="true"
->Feb 8, 2015 2:48:17 PM org.apache.catalina.core.AprLifecycleListener init
+>Nov 29, 2020 2:48:17 PM org.apache.catalina.core.AprLifecycleListener init
 INFO: Loaded APR based Apache Tomcat Native library 1.x.y.
-Feb 8, 2015 2:48:17 PM org.apache.catalina.core.AprLifecycleListener init
-INFO: APR capabilities: IPv6 [false], sendfile [true], accept filters [false], random [true].
-Feb 8, 2015 2:48:18 PM org.apache.coyote.http11.Http11AprProtocol init
+Nov 29, 2020 2:48:17 PM org.apache.catalina.core.AprLifecycleListener init
+INFO: APR capabilities: IPv6 [false], sendfile [true], accept filters [false], random [true], uds [false].
+Nov 29, 2020 2:48:18 PM org.apache.coyote.http11.Http11AprProtocol init
 INFO: Initializing Coyote HTTP/1.1 on http-8080</source>
 
 </subsection>

--- a/xdocs/index.xml
+++ b/xdocs/index.xml
@@ -177,7 +177,7 @@ list of changes.
     </p>
 
     <p>
-      When using unix domain sockets a cleanup is registered to delete the
+      When using Unix Domain Sockets a cleanup is registered to delete the
       socket on destruction of the socket, or shutdown of the application.
       Should the application terminate abnormally, the socket deletion will
       need to be handled by the caller or by the administrator.

--- a/xdocs/index.xml
+++ b/xdocs/index.xml
@@ -199,7 +199,7 @@ export LD_LIBRARY_PATH</source>
 >Nov 29, 2020 12:27:41 PM org.apache.catalina.core.AprLifecycleListener init
 INFO: Loaded APR based Apache Tomcat Native library 1.x.y.
 Nov 29, 2020 12:27:41 PM org.apache.catalina.core.AprLifecycleListener init
-INFO: APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true], uds [true].
+INFO: APR capabilities: IPv6 [true], sendfile [true], accept filters [false], random [true], UDS [true].
 Nov 29, 2020 12:27:41 PM org.apache.coyote.http11.Http11AprProtocol init
 INFO: Initializing Coyote HTTP/1.1 on http-8080</source>
 
@@ -226,7 +226,7 @@ INFO: Initializing Coyote HTTP/1.1 on http-8080</source>
 >Nov 29, 2020 2:48:17 PM org.apache.catalina.core.AprLifecycleListener init
 INFO: Loaded APR based Apache Tomcat Native library 1.x.y.
 Nov 29, 2020 2:48:17 PM org.apache.catalina.core.AprLifecycleListener init
-INFO: APR capabilities: IPv6 [false], sendfile [true], accept filters [false], random [true], uds [false].
+INFO: APR capabilities: IPv6 [false], sendfile [true], accept filters [false], random [true], UDS [false].
 Nov 29, 2020 2:48:18 PM org.apache.coyote.http11.Http11AprProtocol init
 INFO: Initializing Coyote HTTP/1.1 on http-8080</source>
 

--- a/xdocs/miscellaneous/changelog.xml
+++ b/xdocs/miscellaneous/changelog.xml
@@ -39,6 +39,9 @@
     <fix>
       Enable building to continue against OpenSSL 3.x and 1.1.1. (markt)
     </fix>
+    <add>
+      Expose support for Unix Domain Sockets in APR v1.6 and up. (minfrin)
+    </add>
   </changelog>
 </section>
 <section name="Changes in 1.2.25">


### PR DESCRIPTION
This patch adds support for Unix Domain Sockets, that was added to APR v1.6.

This consists of the addition of the APR_UNIX family, as well as adding a cleanup to remove the socket file on shutdown.