### PR TITLE
Fix script to run from different directories

### DIFF
--- a/download_deps.sh
+++ b/download_deps.sh
@@ -3,6 +3,8 @@
 # Small script to get a recent openssl, with npn support
 # Will run configure and build_libs to generate the .s files
 
+cd $(dirname $0)
+
 SSL=openssl-1.1.1n.tar.gz
 APR=apr-1.7.0.tar.gz
 mkdir -p deps


### PR DESCRIPTION
By adding cd $(dirname $0) , user can run script from external directory and not having issues with the actual location of deps directory.