### PR TITLE
native: Fix the build with rlibtool

### DIFF
--- a/native/configure.in
+++ b/native/configure.in
@@ -50,6 +50,9 @@ AC_SUBST(TCN_CONFIG_LOCATION)
 AC_CANONICAL_TARGET
 AC_PROG_INSTALL
 
+dnl Generate the libtool script which is needed for rlibtool
+LT_INIT
+
 dnl
 dnl compute the top directory of the build
 dnl note: this is needed for LIBTOOL and exporting the bundled Expat


### PR DESCRIPTION
When building tomcat-native with slibtool using the rlibtool symlink the build will fail. This is because rlibtool requires the generated libtool script to determine if the build is shared, static or both.

Gentoo bug: https://bugs.gentoo.org/778914