### PR TITLE
BZ 66670: Add SSLHostConfig#certificateKeyPasswordFile and SSLHostCon…

### DIFF
--- a/java/org/apache/tomcat/jni/SSLContext.java
+++ b/java/org/apache/tomcat/jni/SSLContext.java
@@ -177,14 +177,27 @@ public final class SSLContext {
      * @param key Private Key file to use if not in cert.
      * @param password Certificate password. If null and certificate
      *                 is encrypted, password prompt will be displayed.
+     * @param passwordFile Certificate password file. If null and certificate
+     *                 is encrypted, password prompt will be displayed.
      * @param idx Certificate index SSL_AIDX_RSA or SSL_AIDX_DSA.
      * @return <code>true</code> if the operation was successful
      * @throws Exception An error occurred
      */
     public static native boolean setCertificate(long ctx, String cert,
                                                 String key, String password,
-                                                int idx)
+                                                String passwordFile, int idx)
         throws Exception;
+
+    /**
+     * @deprecated use {@link #setCertificate(long, String, String, String, String, int)}
+     */
+    @Deprecated
+    public static boolean setCertificate(long ctx, String cert,
+                                         String key, String password,
+                                         int idx)
+        throws Exception {
+        return setCertificate(ctx, cert, key, password, null, idx);
+    }
 
     /**
      * Set the size of the internal session cache.

--- a/xdocs/miscellaneous/changelog.xml
+++ b/xdocs/miscellaneous/changelog.xml
@@ -34,6 +34,10 @@
 <section name="Changes in 2.0.7">
   <changelog>
     <add>
+      <bug>66670</bug>: Add SSLHostConfig#certificateKeyPasswordFile and
+      SSLHostConfig#certificateKeystorePasswordFile. (michaelo)
+    </add>
+    <add>
       <bug>67538</bug>: Make use of Ant's <code>&lt;javaversion /&gt;</code> task
       to enfore the mininum Java build version. (michaelo)
     </add>


### PR DESCRIPTION
…fig#certificateKeystorePasswordFile

This has been done on purpose because Tomcat is not the only consumer of this library and this should be available consistently to everyone out there.

This is required for the main issue.

Approriate, ready-to-merge branches exist for all active versions.