### PR TITLE
Reinstantiate an updated patch for OpenSSL 1.1.1 on Windows

### DIFF
--- a/native/srclib/openssl/openssl-msvcrt-1.1.1.patch
+++ b/native/srclib/openssl/openssl-msvcrt-1.1.1.patch
@@ -1,0 +1,74 @@
+--- Configurations/10-main.conf
++++ Configurations/10-main.conf
+@@ -1294,7 +1294,7 @@ my %targets = (
+         # prefer [non-debug] openssl.exe to be free from Micorosoft RTL
+         # redistributable.
+         bin_cflags       => add(picker(debug   => "/MDd",
+-                                       release => sub { $disabled{shared} ? "/MT" : () },
++                                       release => "/MD",
+                                       )),
+         bin_lflags       => add("/subsystem:console /opt:ref"),
+         ex_libs          => add(sub {
+--- crypto/engine/eng_openssl.c
++++ crypto/engine/eng_openssl.c
+@@ -9,6 +9,7 @@
+  */
+ 
+ #include <stdio.h>
++#include "e_os.h"
+ #include <openssl/crypto.h>
+ #include "internal/cryptlib.h"
+ #include "crypto/engine.h"
+--- crypto/o_time.c
++++ crypto/o_time.c
+@@ -41,10 +41,6 @@ struct tm *OPENSSL_gmtime(const time_t *timer, struct tm *result)
+     if (gmtime_r(timer, result) == NULL)
+         return NULL;
+     ts = result;
+-#elif defined (OPENSSL_SYS_WINDOWS) && defined(_MSC_VER) && _MSC_VER >= 1400 && !defined(_WIN32_WCE)
+-    if (gmtime_s(result, timer))
+-        return NULL;
+-    ts = result;
+ #else
+     ts = gmtime(timer);
+     if (ts == NULL)
+--- e_os.h
++++ e_os.h
+@@ -177,7 +177,7 @@ static __inline unsigned int _strlen31(const char *str)
+ #   endif
+ #   include <malloc.h>
+ #   if defined(_MSC_VER) && !defined(_WIN32_WCE) && !defined(_DLL) && defined(stdin)
+-#    if _MSC_VER>=1300 && _MSC_VER<1600
++#    ifdef _WIN64
+ #     undef stdin
+ #     undef stdout
+ #     undef stderr
+@@ -185,7 +185,7 @@ FILE *__iob_func();
+ #     define stdin  (&__iob_func()[0])
+ #     define stdout (&__iob_func()[1])
+ #     define stderr (&__iob_func()[2])
+-#    elif _MSC_VER<1300 && defined(I_CAN_LIVE_WITH_LNK4049)
++#    else
+ #     undef stdin
+ #     undef stdout
+ #     undef stderr
+--- engines/e_capi.c
++++ engines/e_capi.c
+@@ -15,6 +15,7 @@
+ # include <wincrypt.h>
+ 
+ # include <stdio.h>
++# include "e_os.h"
+ # include <string.h>
+ # include <stdlib.h>
+ # include <malloc.h>
+--- test/testutil/basic_output.c
++++ test/testutil/basic_output.c
+@@ -10,6 +10,7 @@
+ #include "../testutil.h"
+ #include "output.h"
+ #include "tu_local.h"
++#include "../../e_os.h"
+ 
+ #include <openssl/crypto.h>
+ #include <openssl/bio.h>

--- a/xdocs/miscellaneous/changelog.xml
+++ b/xdocs/miscellaneous/changelog.xml
@@ -41,6 +41,9 @@
     <fix>
       Fix version set in DLL header on Windows. (michaelo)
     </fix>
+    <add>
+      Reinstantiate an updated patch for OpenSSL 1.1.1 on Windows. (michaelo)
+    </add>
   </changelog>
 </section>
 <section name="Changes in 1.2.39">


### PR DESCRIPTION
This patch has been recently removed because it does not apply to the latest version. Bring back an updated patch because Tomcat Native 1.2.x still supports 1.1.1 for those who need it on Windows, but strongly recommends to use 3.0 or newer.