### PR TITLE
Openssl changelog update

### DIFF
--- a/xdocs/miscellaneous/changelog.xml
+++ b/xdocs/miscellaneous/changelog.xml
@@ -69,6 +69,9 @@
       Remove NPN support as NPN was never standardised and browser support was
       removed in 2019. (markt)
     </design>
+    <update>
+      Update the recommended minimum version of OpenSSL to 3.0.13. (markt)
+    </update>
   </changelog>
 </section>
 <section name="Changes in 1.2.x">


### PR DESCRIPTION
Add to changelog that the recommended minimum version of OpenSSL has been updated to 3.0.13 with 1.3.0 release.