### PR TITLE
Fix client ca cert Native Leak when startUp and reload

### DIFF
--- a/native/src/sslcontext.c
+++ b/native/src/sslcontext.c
@@ -1234,6 +1234,9 @@ TCN_IMPLEMENT_CALL(jboolean, SSLContext, addClientCACertificateRaw)(TCN_STDARGS,
         rv = JNI_FALSE;
     }
 
+    if (cert != NULL) {
+        X509_free(cert);
+    }
     free(charCert);
     return rv;
 }


### PR DESCRIPTION
Ensure the allocated client ca cert memory is properly reclaimed, which is dangerous if a tomcat-based multi-tenants gateway service with  dynamic SNI feature or tenant cert configuration hot reload feature enabled. The native heap ignore -Xmx settings, is invisible to most standard java monitoring tools until the ENTIRE OS RUNS OOM. 

Deterministic native mem leak is realistic, per observation in PoC, via /manager/text/sslReload x 10000 times → 12.6MB

Originally, an X509 certificate object is allocated via d2i_X509 but is never released after being added to the SSL context.